### PR TITLE
Emily Update:

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -29,18 +29,39 @@ const Settings = () => {
                 return;
             }
         }
-        const confirmed = window.confirm('Are you sure you want to permanently delete your account?');
-        if (!confirmed) return;
+        // ask via toast instead of window.confirm
+        toast((t) => (
+            <div className="space-y-2">
+                <p>Are you sure you want to permanently delete your account?</p>
+                <div className="flex justify-end space-x-2">
+                    <button
+                        className="btn btn-error btn-sm"
+                        onClick={async () => {
+                            toast.dismiss(t.id);
+                            try {
+                                await axios.delete(`/api/users/${user._id}`);
+                                toast.success('Account deleted successfully');
+                                logout();
+                                navigate('/');
+                            } catch (err) {
+                                console.error('Delete failed', err);
+                                toast.error('Failed to delete account');
+                            }
+                        }}
+                    >
+                        Yes, delete
+                    </button>
+                    <button
+                        className="btn btn-outline btn-sm"
+                        onClick={() => toast.dismiss(t.id)}
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        ), { duration: Infinity });
+        return;
 
-        try {
-            await axios.delete(`/api/users/${user._id}`);
-            toast.success('Account deleted successfully');
-            logout();
-            navigate('/');
-        } catch (err) {
-            console.error('Delete failed', err);
-            toast.error('Failed to delete account');
-        }
     };
 
     return (


### PR DESCRIPTION
File: ./frontend/src/pages/Settings.jsx
-->Removed the standard browser confirmation dialog and instead showed a small popup (toast) at the top of the screen asking if the user is sure they want to delete their account. The popup has two buttons: "Yes, delete" and "Cancel." Clicking "Yes, delete" runs the code to delete the account, shows success or error messages, logs the user out, and sends them back to the home page. Clicking "Cancel" just closes the popup. The "return;" line makes sure no other code runs until the user chooses one of those buttons.