### PR TITLE
Emily Update:

### DIFF
--- a/frontend/src/pages/TeacherNewsfeed.jsx
+++ b/frontend/src/pages/TeacherNewsfeed.jsx
@@ -41,6 +41,12 @@ export default function TeacherNewsfeed() {
     }, [classId]);
 
     const handlePost = async () => {
+        // Prevent empty announcement
+        const plainText = draft.replace(/<(.|\n)*?>/g, '').trim();
+        if (!plainText) {
+            toast.error('Please enter an announcement before posting');
+            return;
+        }
         const formData = new FormData();
         formData.append('content', draft);
         attachments.forEach(file => formData.append('attachments', file));
@@ -52,15 +58,36 @@ export default function TeacherNewsfeed() {
 
     };
 
-    const handleDelete = async (itemId) => {
-        try {
-            await deleteNews(classId, itemId);
-            setItems(items.filter(item => item._id !== itemId));
-            toast.success('Announcement deleted');
-        } catch (err) {
-            console.error('Delete failed', err);
-            toast.error('Failed to delete');
-        }
+    const handleDelete = (itemId) => {
+        toast((t) => (
+            <div className="flex flex-col">
+                <span>Are you sure you want to delete this announcement?</span>
+                <div className="mt-2">
+                    <button
+                        className="bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded mr-2"
+                        onClick={async () => {
+                            try {
+                                await deleteNews(classId, itemId);
+                                setItems(items.filter(item => item._id !== itemId));
+                                toast.success('Announcement deleted');
+                            } catch (err) {
+                                console.error('Delete failed', err);
+                                toast.error('Failed to delete');
+                            }
+                            toast.dismiss(t.id);
+                        }}
+                    >
+                        Yes
+                    </button>
+                    <button
+                        className="bg-gray-300 hover:bg-gray-400 text-black px-3 py-1 rounded"
+                        onClick={() => toast.dismiss(t.id)}
+                    >
+                        No
+                    </button>
+                </div>
+            </div>
+        ));
     };
 
     const handleEdit = async (itemId, newContent) => {
@@ -115,7 +142,6 @@ export default function TeacherNewsfeed() {
                     <button
                         className="bg-green-500 hover:bg-green-600 text-white px-6 py-2 rounded-lg"
                         onClick={handlePost}
-                        disabled={!draft.trim()}
                     >
                         Post
                     </button>


### PR DESCRIPTION
File: ./frontend/src/pages/TeacherNewsfeed.jsx
-->Checked if the announcement is actually empty by stripping HTML tags and whitespace. If it is empty, it shows an error message using a toast and stops the post from being submitted. -->The Post button was previously disabled unless there was input. This change makes it always clickable so our custom validation can run and show an error if the content is empty. -->Replaced the browser's default confirm dialog with a styled toast popup that asks the user to confirm or cancel the delete action. If they click 'Yes', it proceeds with the deletion.