### PR TITLE
Move footer all way at bottom of people page to be consistent with other pages

### DIFF
--- a/frontend/src/pages/People.jsx
+++ b/frontend/src/pages/People.jsx
@@ -182,8 +182,8 @@ const People = () => {
   };
 
   return (
-    <div className="flex flex-col min-h-[calc(100vh-5rem)] p-6 max-w-5xl mx-auto">
-      <div className="flex-grow">
+    <div className="flex flex-col min-h-screen">
+      <main className="flex-grow p-6 max-w-5xl mx-auto">
         <div className="mb-6">
           <h1 className="text-3xl font-bold">
             {classroom ? `${classroom.name} People` : 'People'}
@@ -421,7 +421,7 @@ const People = () => {
             )}
           </div>
         )}
-      </div>
+      </main>
       <Footer />
     </div>
   );


### PR DESCRIPTION
This pull request updates the layout structure of the `People` page to improve semantic HTML and layout consistency. The main content is now wrapped in a `<main>` element, and the overall page uses a more standard full-height layout.

Layout and semantic improvements:

* Changed the root container in `People.jsx` to use `min-h-screen` instead of a calculated height and moved the main content into a semantic `<main>` tag with proper padding and max width.
* Updated the closing structure so that the `<Footer />` is now outside the `<main>` element, clarifying the page's structure.