### PR TITLE
Move footer all way at bottom of people page to be consistent with other pages

### DIFF
--- a/frontend/src/pages/People.jsx
+++ b/frontend/src/pages/People.jsx
@@ -182,8 +182,8 @@ const People = () => {
   };
 
   return (
-    <div className="flex flex-col min-h-[calc(100vh-5rem)] p-6 max-w-5xl mx-auto">
-      <div className="flex-grow">
+    <div className="flex flex-col min-h-screen">
+      <main className="flex-grow p-6 max-w-5xl mx-auto">
         <div className="mb-6">
           <h1 className="text-3xl font-bold">
             {classroom ? `${classroom.name} People` : 'People'}
@@ -421,7 +421,7 @@ const People = () => {
             )}
           </div>
         )}
-      </div>
+      </main>
       <Footer />
     </div>
   );


### PR DESCRIPTION
This pull request makes a minor structural update to the `People` page layout. The main content is now wrapped in a `<main>` element with improved padding and height handling, which enhances semantic HTML and layout consistency.

- Layout and semantic improvements:
  * Changed the outer container in `People.jsx` to use `min-h-screen` for full viewport height and wrapped the main content in a `<main>` element with appropriate padding and width classes. [[1]](diffhunk://#diff-613e8722c3c5f84939a6d903d7a41193358346e40207e5fd1596daa45101e193L185-R186) [[2]](diffhunk://#diff-613e8722c3c5f84939a6d903d7a41193358346e40207e5fd1596daa45101e193L424-R424)