### PR TITLE
refactor: Update image URL handling to use relative paths in Bazaar routes to fix local image upload issue in prod

### DIFF
--- a/backend/routes/bazaar.js
+++ b/backend/routes/bazaar.js
@@ -26,9 +26,9 @@ router.post(
   async (req, res) => {
     const { classroomId } = req.params;
     // prefer uploaded file, fall back to image URL from body (if any)
-    // build absolute URL so frontend can fetch regardless of dev server origin
+    // build relative path so frontend decides full URL via API_BASE
     const image = req.file
-      ? `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`
+      ? `/uploads/${req.file.filename}`
       : (req.body.image || undefined);
 
     try {
@@ -75,7 +75,7 @@ router.post('/classroom/:classroomId/bazaar/:bazaarId/items', ensureAuthenticate
   const { name, description, price, category, primaryEffect, primaryEffectValue } = req.body;
   // Prefer uploaded file, fallback to image URL
   const image = req.file
-    ? `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`
+    ? `/uploads/${req.file.filename}`
     : (req.body.image || undefined);
 
   // Parse JSON fields that may arrive as strings when using multipart/form-data


### PR DESCRIPTION
This pull request updates how image URLs are constructed in the `backend/routes/bazaar.js` file. Instead of building absolute URLs using the protocol and host, the code now generates relative paths for uploaded images. This change allows the frontend to determine the full URL using its configured API base, improving flexibility across different environments.

**Image URL handling updates:**

* Changed image URL construction to use relative paths (`/uploads/<filename>`) instead of absolute URLs in both the classroom and item creation endpoints. [[1]](diffhunk://#diff-082a3049defe229c9ea54248c130484a584d374348175f23c4f6611a3396ea9cL29-R31) [[2]](diffhunk://#diff-082a3049defe229c9ea54248c130484a584d374348175f23c4f6611a3396ea9cL78-R78)