### PR TITLE
refactor: Update image URL handling to use relative paths in Bazaar routes to fix local image upload issue in prod

### DIFF
--- a/backend/routes/bazaar.js
+++ b/backend/routes/bazaar.js
@@ -26,9 +26,9 @@ router.post(
   async (req, res) => {
     const { classroomId } = req.params;
     // prefer uploaded file, fall back to image URL from body (if any)
-    // build absolute URL so frontend can fetch regardless of dev server origin
+    // build relative path so frontend decides full URL via API_BASE
     const image = req.file
-      ? `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`
+      ? `/uploads/${req.file.filename}`
       : (req.body.image || undefined);
 
     try {
@@ -75,7 +75,7 @@ router.post('/classroom/:classroomId/bazaar/:bazaarId/items', ensureAuthenticate
   const { name, description, price, category, primaryEffect, primaryEffectValue } = req.body;
   // Prefer uploaded file, fallback to image URL
   const image = req.file
-    ? `${req.protocol}://${req.get('host')}/uploads/${req.file.filename}`
+    ? `/uploads/${req.file.filename}`
     : (req.body.image || undefined);
 
   // Parse JSON fields that may arrive as strings when using multipart/form-data

--- a/frontend/src/pages/People.jsx
+++ b/frontend/src/pages/People.jsx
@@ -183,7 +183,7 @@ const People = () => {
 
   return (
     <div className="flex flex-col min-h-screen">
-      <main className="flex-grow p-6 max-w-5xl mx-auto">
+      <main className="flex-grow p-6 w-full max-w-5xl mx-auto">
         <div className="mb-6">
           <h1 className="text-3xl font-bold">
             {classroom ? `${classroom.name} People` : 'People'}
@@ -214,8 +214,8 @@ const People = () => {
         </div>
 {/* ─────────────── Settings TAB ─────────────── */}
         {tab === 'settings' && (user?.role || '').toLowerCase() === 'teacher' && (
-          <div className="max-w-md space-y-6">
-            <h2 className="text-2xl font-semibold">Classroom Settings</h2>
+          <div className="w-full space-y-6 min-w-0">
+             <h2 className="text-2xl font-semibold">Classroom Settings</h2>
 
             <label className="form-control w-full">
               <span className="label-text mb-2 font-medium">
@@ -381,24 +381,24 @@ const People = () => {
         )}
 
         {tab === 'groups' && (
-          <div className="space-y-6">
+          <div className="space-y-6 w-full min-w-0">
             {groupSets.length === 0 ? (
               <p>No groups available yet.</p>
             ) : (
               groupSets.map((gs) => (
-                <div key={gs._id}>
+                <div key={gs._id} className="w-full min-w-0">
                   <h2 className="text-xl font-semibold">{gs.name}</h2>
-                  <div className="ml-4 mt-2 space-y-4">
+                  <div className="mt-2 grid grid-cols-1 gap-4 w-full">
                     {gs.groups.map((group) => (
-                      <div key={group._id} className="border p-4 rounded">
-                        <h3 className="text-lg font-bold">{group.name}</h3>
-                        {group.members.length === 0 ? (
-                          <p className="text-gray-500">No members</p>
+                      <div key={group._id} className="border p-4 rounded w-full min-w-0 bg-base-100">
+                         <h3 className="text-lg font-bold">{group.name}</h3>
+                         {group.members.length === 0 ? (
+                           <p className="text-gray-500">No members</p>
                         ) : (
                           <ul className="list-disc ml-5 space-y-1">
                             {group.members.map((m) => (
-                              <li key={m._id._id} className="flex justify-between items-center">
-                                <span>
+                              <li key={m._id._id} className="flex justify-between items-center w-full">
+                                 <span>
                                   {m._id.firstName || m._id.lastName
                                     ? `${m._id.firstName || ''} ${m._id.lastName || ''}`.trim()
                                     : m._id.name || m._id.email}
@@ -414,17 +414,17 @@ const People = () => {
                           </ul>
                         )}
                       </div>
-                    ))}
+                     ))}
                   </div>
                 </div>
               ))
-            )}
+             )}
           </div>
         )}
       </main>
-      <Footer />
-    </div>
-  );
-};
-
-export default People;
+       <Footer />
+     </div>
+   );
+ };
+ 
+ export default People;


### PR DESCRIPTION
This pull request updates how image URLs are constructed for uploaded files in the `backend/routes/bazaar.js` API endpoints. Instead of building absolute URLs on the backend, the code now returns relative paths, allowing the frontend to determine the full URL using its own configuration. This change improves flexibility and compatibility across different deployment environments.

**Backend API changes:**

* Changed image URL construction in `router.post(` to return a relative path (`/uploads/filename`) instead of an absolute URL, delegating full URL resolution to the frontend.
* Made the same change in the image URL construction for the `/classroom/:classroomId/bazaar/:bazaarId/items` endpoint, ensuring consistency in how image paths are handled.