### PR TITLE
Added join Date, enhanced siphon notifs, improved bazaar item descritption formatting and accounting for secondary effects

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -58,6 +58,11 @@ const UserSchema = new mongoose.Schema({
     classroom: { type: mongoose.Schema.Types.ObjectId, ref: 'Classroom' },
     balance: { type: Number, default: 0, min: 0 }
   }],
+  // Add classroom join dates tracking
+  classroomJoinDates: [{
+    classroom: { type: mongoose.Schema.Types.ObjectId, ref: 'Classroom' },
+    joinedAt: { type: Date, default: Date.now }
+  }],
   groups: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Group' }],
   transactions: [TransactionSchema],
   isBanned: { type: Boolean, default: false },

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -83,6 +83,8 @@ const UserSchema = new mongoose.Schema({
     match: /^[A-Z]{2}\d{4}$/,
   },
 
+}, { 
+  timestamps: true  // This should be here to automatically add createdAt and updatedAt
 });
 
 UserSchema.pre('validate', async function (next) {

--- a/backend/routes/profile.js
+++ b/backend/routes/profile.js
@@ -24,6 +24,16 @@ router.get('/student/:id', ensureAuthenticated, async (req, res) => {
 
     // Convert to plain object so we can safely modify/override fields for response
     const userObj = user.toObject();
+    
+    // Debug: Log what we actually have
+    console.log('[Profile Debug] user.createdAt:', user.createdAt);
+    console.log('[Profile Debug] userObj.createdAt:', userObj.createdAt);
+    console.log('[Profile Debug] user._id:', user._id);
+    
+    // Ensure createdAt is included
+    if (!userObj.createdAt && user.createdAt) {
+      userObj.createdAt = user.createdAt;
+    }
 
     // Guard classroomBalances (may be undefined)
     if (classroomId && Array.isArray(userObj.classroomBalances)) {

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -384,7 +384,11 @@ router.post('/bulk-upload', ensureAuthenticated, async (req, res) => {
       lastName,
       role,
       classrooms: [classroomId],
-      balance: initialBalance
+      balance: initialBalance,
+      classroomJoinDates: [{
+        classroom: classroomId,
+        joinedAt: new Date()
+      }]
     });
     await newUser.save();
 

--- a/frontend/src/components/InventorySection.jsx
+++ b/frontend/src/components/InventorySection.jsx
@@ -25,7 +25,7 @@ const InventorySection = ({ userId, classroomId }) => {
     const load = async () => {
       try {
         const [invRes, studentRes] = await Promise.all([
-          apiBazaar.get(`/inventory/${userId}`),
+          apiBazaar.get(`/inventory/${userId}?classroomId=${classroomId}`), // Add classroomId query param
           apiClassroom.get(`/${classroomId}/students`)
         ]);
         setItems(invRes.data.items);
@@ -72,7 +72,7 @@ const InventorySection = ({ userId, classroomId }) => {
       toast.success(response.data.message || 'Swap successful!');
       
       // Refresh inventory
-      const invRes = await apiBazaar.get(`/inventory/${userId}`);
+      const invRes = await apiBazaar.get(`/inventory/${userId}?classroomId=${classroomId}`); // Add classroomId query param
       setItems(invRes.data.items);
     } catch (err) {
       console.error('Swap failed:', err);
@@ -138,7 +138,7 @@ const InventorySection = ({ userId, classroomId }) => {
       toast.success(response.data.message || 'Item used successfully!');
       
       // Refresh inventory
-      const invRes = await apiBazaar.get(`/inventory/${userId}`);
+      const invRes = await apiBazaar.get(`/inventory/${userId}?classroomId=${classroomId}`); // Add classroomId query param
       setItems(invRes.data.items);
       
     } catch (err) {
@@ -165,7 +165,7 @@ const InventorySection = ({ userId, classroomId }) => {
       toast.success(response.data.message || 'Nullify successful!');
       
       // Refresh inventory
-      const invRes = await apiBazaar.get(`/inventory/${userId}`);
+      const invRes = await apiBazaar.get(`/inventory/${userId}?classroomId=${classroomId}`); // Add classroomId query param
       setItems(invRes.data.items);
     } catch (err) {
       console.error('Nullify failed:', err);

--- a/frontend/src/components/ItemCard.jsx
+++ b/frontend/src/components/ItemCard.jsx
@@ -7,6 +7,7 @@ import { ShoppingCart } from 'lucide-react';
 import { useCart } from '../context/CartContext';
 import { useAuth } from '../context/AuthContext.jsx';
 import { resolveImageSrc } from '../utils/image';
+import { splitDescriptionEffect, getEffectDescription } from '../utils/itemHelpers';
 
 const ItemCard = ({ item, role, classroomId }) => {
   const [quantity, setQuantity] = useState(1);
@@ -64,6 +65,8 @@ const ItemCard = ({ item, role, classroomId }) => {
     return `${finalPrice} ₿`;
   };
 
+  const { main, effect } = splitDescriptionEffect(item.description || '');
+
   return (
     <div className="card bg-base-100 shadow-md border border-base-200 hover:shadow-lg transition duration-200 rounded-2xl overflow-hidden">
       {/* Image */}
@@ -86,7 +89,22 @@ const ItemCard = ({ item, role, classroomId }) => {
          <h3 className="card-title text-lg md:text-xl font-semibold">
            {item.name}
          </h3>
-        <p className="text-base-content opacity-70 text-sm mt-2">{item.description}</p>
+        <p className="text-sm text-base-content/70 whitespace-pre-wrap">
+          {main || 'No description provided.'}
+        </p>
+
+        {effect && (
+          <div className="text-sm text-base-content/60 mt-1">
+            <strong>Effect:</strong> {effect}
+          </div>
+        )}
+
+        {!effect && getEffectDescription(item) && (
+          <div className="text-sm text-base-content/60 mt-1">
+            <strong>Effect:</strong> {getEffectDescription(item)}
+          </div>
+        )}
+
         <p className="text-base-content font-bold text-base">
            {calculatePrice()}
          </p>

--- a/frontend/src/components/TransactionList.jsx
+++ b/frontend/src/components/TransactionList.jsx
@@ -137,7 +137,7 @@ const TransactionList = ({ transactions }) => {
                 {(tx.items && tx.items.length > 0 ? tx.items : orderCache[tx.orderId] || []).map((it) => {
                    // Split description into main + Effect (same helper used by OrderCard)
                    const { main: descMain, effect: effectFromDesc } = splitDescriptionEffect(it.description || '');
-                   const autoEffect = !effectFromDesc && getEffectDescription(it);
+                   const autoEffect = getEffectDescription(it);
                    return (
                      <div key={it.id || it._id || it.name} className="flex items-start gap-3">
                        <div className="w-10 h-10 bg-base-200 rounded overflow-hidden flex items-center justify-center flex-shrink-0">
@@ -162,7 +162,7 @@ const TransactionList = ({ transactions }) => {
                            <div className="text-xs text-base-content/70 whitespace-pre-wrap mt-1">
                              {descMain}
                            </div>
-                         ) : it.description ? (
+                         ) : it.description && !effectFromDesc ? (
                            <div className="text-xs text-base-content/70 line-clamp-2 mt-1">
                              {it.description}
                            </div>

--- a/frontend/src/pages/Groups.jsx
+++ b/frontend/src/pages/Groups.jsx
@@ -855,15 +855,22 @@ const Groups = () => {
                   type="checkbox"
                   className="toggle toggle-primary"
                   checked={groupSetSelfSignup}
-                  onChange={(e) => setGroupSetSelfSignup(e.target.checked)}
+                  onChange={(e) => {
+                    setGroupSetSelfSignup(e.target.checked);
+                    // Auto-disable join approval if self-signup is disabled
+                    if (!e.target.checked) {
+                      setGroupSetJoinApproval(false);
+                    }
+                  }}
                 />
                 Self Signup
               </label>
-              <label className="flex items-center gap-2">
+              <label className={`flex items-center gap-2 ${!groupSetSelfSignup ? 'opacity-50' : ''}`}>
                 <input
                   type="checkbox"
                   className="toggle toggle-primary"
-                  checked={groupSetJoinApproval}
+                  checked={groupSetJoinApproval && groupSetSelfSignup} // Auto-uncheck if self-signup disabled
+                  disabled={!groupSetSelfSignup} // Disable when self-signup is off
                   onChange={(e) => setGroupSetJoinApproval(e.target.checked)}
                 />
                 Join Approval Required
@@ -1189,13 +1196,21 @@ const Groups = () => {
 
                         return (
                           <>
-                            {!studentMembership && !alreadyApprovedInGroupSet && !hasPendingInGroupSet && (
+                            {/* Only show join button if self-signup is enabled */}
+                            {!studentMembership && !alreadyApprovedInGroupSet && !hasPendingInGroupSet && gs.selfSignup && (
                               <button
                                 className="btn btn-xs btn-success"
                                 onClick={() => handleJoinGroup(gs._id, group._id)}
                               >
                                 Join
                               </button>
+                            )}
+
+                            {/* Show message when self-signup is disabled */}
+                            {!studentMembership && !alreadyApprovedInGroupSet && !hasPendingInGroupSet && !gs.selfSignup && (
+                              <span className="text-xs text-gray-500">
+                                Manual enrollment only
+                              </span>
                             )}
 
                             {isPending && (
@@ -1219,6 +1234,7 @@ const Groups = () => {
                                 >
                                   Leave
                                 </button>
+                                {/* Only show siphon button to group members */}
                                 <button
                                   className="btn btn-xs btn-warning"
                                   onClick={() => setOpenSiphonModal(group)}
@@ -1260,8 +1276,12 @@ const Groups = () => {
                       )}
                     </div>
 
-                    {/* Siphon requests */}
+                    {/* Siphon requests - Only show to group members, teachers, and admins */}
                     {group.siphonRequests?.length > 0 && (
+                      user.role === 'teacher' || 
+                      user.role === 'admin' || 
+                      group.members.some(m => m._id && m._id._id === user._id && m.status === 'approved')
+                    ) && (
                       <div className="mt-4">
                         <h5 className="text-sm font-semibold">Active Siphon Requests</h5>
                         {group.siphonRequests
@@ -1412,7 +1432,15 @@ const Groups = () => {
                                         View Profile
                                       </button>
                                       {member._id.isFrozen && (
-                                        <Lock className="inline w-4 h-4 ml-1 text-red-500" title="Balance frozen" />
+                                        // Only show frozen icon to group members, teachers, and admins
+                                        (user.role === 'teacher' || 
+                                         user.role === 'admin' || 
+                                         group.members.some(m => m._id && m._id._id === user._id && m.status === 'approved')
+                                        ) && (
+                                          <div className="tooltip" data-tip="Account frozen due to siphon request">
+                                            <Lock className="inline w-4 h-4 ml-1 text-red-500 cursor-help" />
+                                          </div>
+                                        )
                                       )}
                                     </td>
                                     <td>
@@ -1464,15 +1492,22 @@ const Groups = () => {
                   type="checkbox"
                   className="toggle toggle-primary"
                   checked={groupSetSelfSignup}
-                  onChange={(e) => setGroupSetSelfSignup(e.target.checked)}
+                  onChange={(e) => {
+                    setGroupSetSelfSignup(e.target.checked);
+                    // Auto-disable join approval if self-signup is disabled
+                    if (!e.target.checked) {
+                      setGroupSetJoinApproval(false);
+                    }
+                  }}
                 />
                 Self Signup
               </label>
-              <label className="flex items-center gap-2">
+              <label className={`flex items-center gap-2 ${!groupSetSelfSignup ? 'opacity-50' : ''}`}>
                 <input
                   type="checkbox"
                   className="toggle toggle-primary"
-                  checked={groupSetJoinApproval}
+                  checked={groupSetJoinApproval && groupSetSelfSignup} // Auto-uncheck if self-signup disabled
+                  disabled={!groupSetSelfSignup} // Disable when self-signup is off
                   onChange={(e) => setGroupSetJoinApproval(e.target.checked)}
                 />
                 Join Approval Required
@@ -1758,7 +1793,7 @@ const Groups = () => {
               </button>
               <button
                 onClick={handleLeaveGroup}
-                className="btn btn-sm btn-error"
+                               className="btn btn-sm btn-error"
               >
                 Yes, Leave
               </button>

--- a/frontend/src/pages/People.jsx
+++ b/frontend/src/pages/People.jsx
@@ -969,9 +969,9 @@ const getGroupAssignmentStats = (students, groupSets) => {
                       {/* Add join date display */}
                       <div className="text-sm text-gray-500 mt-1">
                         Joined: {student.joinedAt 
-                          ? new Date(student.joinedAt).toLocaleDateString() 
+                          ? new Date(student.joinedAt).toLocaleString() 
                           : student.createdAt 
-                            ? new Date(student.createdAt).toLocaleDateString()
+                            ? new Date(student.createdAt).toLocaleString()
                             : 'Unknown'
                         }
                       </div>

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -591,6 +591,22 @@ export default function Profile() {
                     <InfoRow label="Email" value={profile?.email || 'N/A'} />
                     <InfoRow label="User ID" value={profile?.shortId || '—'} />
                     {profile?.role && <InfoRow label="Role" value={ROLE_LABELS[profile.role] || profile.role} />}
+                    
+                    {/* Add Member Since row */}
+                    <InfoRow 
+                      label="Member Since" 
+                      value={profile?.createdAt || user?.createdAt
+                        ? new Date(profile?.createdAt || user?.createdAt).toLocaleString('en-US', {
+                            year: 'numeric',
+                            month: 'long',
+                            day: 'numeric',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            hour12: true
+                          })
+                        : 'Unknown'
+                      } 
+                    />
 
                     {/* Edit / Save controls */}
                     {String(user?._id) === String(profileId || profile?._id) && (

--- a/frontend/src/pages/Wallet.jsx
+++ b/frontend/src/pages/Wallet.jsx
@@ -188,7 +188,8 @@ const Wallet = () => {
       // Update role matching to include siphon
       const roleMatch = roleFilter === 'all' || 
                        (assignerRole === roleFilter) ||
-                       (roleFilter === 'siphon' && isSiphon);
+                       (roleFilter === 'siphon' && isSiphon) ||
+                       (roleFilter === 'purchase' && tx.type === 'purchase');
 
       const directionMatch =
         directionFilter === 'all'
@@ -554,6 +555,7 @@ useEffect(() => {
               disabled={!!assignerFilter}
             >
               <option value="all">All Types</option>
+              <option value="purchase">Checkout</option>
               <option value="teacher">Adjustment by Teacher</option>
               <option value="admin">Adjustment by Admin/TA</option>
               <option value="siphon">Siphon Transfers</option>
@@ -757,6 +759,7 @@ useEffect(() => {
                   disabled={!!assignerFilter}
                 >
                   <option value="all">All Types</option>
+                  <option value="purchase">Checkout</option>
                   <option value="teacher">Adjustment by Teacher</option>
                   <option value="admin">Adjustment by Admin/TA</option>
                   <option value="siphon">Siphon Transfers</option>

--- a/frontend/src/utils/itemHelpers.js
+++ b/frontend/src/utils/itemHelpers.js
@@ -40,6 +40,7 @@ export const getEffectDescription = (item) => {
 export const describeEffectFromForm = (form) => {
   if (!form || !form.category) return '';
   // Mirror same logic but for form fields (when item being created)
+  // PRIMARY / PASSIVE handling (unchanged for primary effects)
   if (form.category === 'Passive') {
     const effects = (form.secondaryEffects || []).map(e => {
       switch (e.effectType) {
@@ -52,17 +53,46 @@ export const describeEffectFromForm = (form) => {
     return effects.length ? `Passive: ${effects.join(', ')}` : '';
   }
 
+  // Helper to format secondary effects (attack-style)
+  const formatSecondary = (secList = []) => {
+    const parts = (secList || []).map(e => {
+      if (!e || !e.effectType) return '';
+      switch (e.effectType) {
+        case 'attackLuck': return `Attack Luck -${e.value}`;
+        case 'attackMultiplier': return `Attack Multiplier -${e.value}x`;
+        case 'attackGroupMultiplier': return `Attack Group Multiplier -${e.value}x`;
+        case 'grantsLuck': return `+${e.value} Luck`;
+        case 'grantsMultiplier': return `+${e.value}x Multiplier`;
+        case 'grantsGroupMultiplier': return `+${e.value}x Group Multiplier`;
+        default: return '';
+      }
+    }).filter(Boolean);
+    return parts.length ? parts.join(', ') : '';
+  };
+
+  // Attack (primary)
   if (form.category === 'Attack') {
-    if (form.primaryEffect === 'swapper') return 'Swaps attributes with target (bits, multiplier, or luck)';
-    if (form.primaryEffect === 'halveBits') return 'Halves target bits';
+    let primary = '';
+    if (form.primaryEffect === 'swapper') primary = 'Swaps attributes with target (bits, multiplier, or luck)';
+    if (form.primaryEffect === 'halveBits') primary = 'Halves target bits';
     if (form.primaryEffect === 'stealBits') {
       const pct = form.primaryEffectValue || 10;
-      return `Steals ${pct}% of target bits`;
+      primary = `Steals ${pct}% of target bits`;
     }
+
+    const secondaryText = formatSecondary(form.secondaryEffects);
+    if (primary && secondaryText) return `${primary}. Secondary: ${secondaryText}`;
+    if (primary) return primary;
+    if (secondaryText) return `Secondary: ${secondaryText}`;
+    return '';
   }
 
-  if (form.category === 'Defend' && form.primaryEffect === 'shield') return 'Blocks one attack (shield)';
+  // Defend
+  if (form.category === 'Defend') {
+    if (form.primaryEffect === 'shield') return 'Blocks one attack (shield)';
+  }
 
+  // Utility
   if (form.category === 'Utility') {
     if (form.primaryEffect === 'doubleEarnings') return '2x earnings multiplier';
     if (form.primaryEffect === 'discountShop') return '20% shop discount';


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to classroom, user, bazaar, profile, siphon, and stats functionality. The most significant changes are the addition of per-classroom join date tracking for users, improved notification logic for classroom and siphon events, more robust filtering and data enrichment in API responses, and better error handling. These updates improve auditability, user experience, and data accuracy across the backend.

### User & Classroom Join Dates

* Added a `classroomJoinDates` array to the `User` schema to track when each user (including teachers) joins a classroom. This is updated on classroom creation, join, leave, and student removal, ensuring join dates are accurate and refreshed on re-entry. (`backend/models/User.js`, `backend/routes/classroom.js`) [[1]](diffhunk://#diff-a6d07b5297ce9bf405466645a67e1f98bc73533b55c042490553a04fe946de87R61-R65) [[2]](diffhunk://#diff-8bf345992946eeb9598dd5399e3e47d65810ebe445fdec3288d11c8cf80862f6L97-R121) [[3]](diffhunk://#diff-8bf345992946eeb9598dd5399e3e47d65810ebe445fdec3288d11c8cf80862f6L145-R177) [[4]](diffhunk://#diff-8bf345992946eeb9598dd5399e3e47d65810ebe445fdec3288d11c8cf80862f6R556-R568) [[5]](diffhunk://#diff-8bf345992946eeb9598dd5399e3e47d65810ebe445fdec3288d11c8cf80862f6R666-R678)

* The `User` schema now uses Mongoose's `timestamps` option to automatically add `createdAt` and `updatedAt` fields. (`backend/models/User.js`)

### Classroom & Student API Improvements

* Classroom student listing now includes both teacher and students, with their balances and accurate per-classroom join dates. The teacher is not duplicated if already in the student list. (`backend/routes/classroom.js`)

* When a user leaves or is removed from a classroom, their `classroomJoinDates` entry for that classroom is deleted, so future joins record a new join date. (`backend/routes/classroom.js`) [[1]](diffhunk://#diff-8bf345992946eeb9598dd5399e3e47d65810ebe445fdec3288d11c8cf80862f6R556-R568) [[2]](diffhunk://#diff-8bf345992946eeb9598dd5399e3e47d65810ebe445fdec3288d11c8cf80862f6R666-R678)

### Notification & Real-time Events

* Improved notification and socket event logic for classroom deletion and student removal, including sending real-time classroom removal events and converting classroom IDs to strings for consistency. (`backend/routes/classroom.js`) [[1]](diffhunk://#diff-8bf345992946eeb9598dd5399e3e47d65810ebe445fdec3288d11c8cf80862f6R411) [[2]](diffhunk://#diff-8bf345992946eeb9598dd5399e3e47d65810ebe445fdec3288d11c8cf80862f6R424-R431) [[3]](diffhunk://#diff-8bf345992946eeb9598dd5399e3e47d65810ebe445fdec3288d11c8cf80862f6L610-R689)

* Siphon request voting now sends detailed notifications to all involved group members and the target user for both approval and rejection outcomes, including vote counts and status explanations. (`backend/routes/siphon.js`) [[1]](diffhunk://#diff-828dac939f9db0e9e2a72e0ecc60ab6dde4207d4b9c0161d0172f0e2192597e3L110-R137) [[2]](diffhunk://#diff-828dac939f9db0e9e2a72e0ecc60ab6dde4207d4b9c0161d0172f0e2192597e3R191-R223) [[3]](diffhunk://#diff-828dac939f9db0e9e2a72e0ecc60ab6dde4207d4b9c0161d0172f0e2192597e3R233-R272)

### Bazaar & Inventory Filtering

* Bazaar order and inventory endpoints now support classroom-based filtering, allowing teachers to view only orders/items relevant to their classrooms and students to filter inventory by classroom. (`backend/routes/bazaar.js`) [[1]](diffhunk://#diff-082a3049defe229c9ea54248c130484a584d374348175f23c4f6611a3396ea9cL401-R455) [[2]](diffhunk://#diff-082a3049defe229c9ea54248c130484a584d374348175f23c4f6611a3396ea9cL438-R508)

### Data Consistency & Stats

* Profile and stats endpoints ensure `createdAt` is present and calculate group multipliers accurately based on current group memberships, improving auditability and accuracy. (`backend/routes/profile.js`, `backend/routes/stats.js`) [[1]](diffhunk://#diff-8641d7c491c2a88485dccf89b6a56cc9ca3f1c3c030a5d56f8a4bf0438a25ebfR28-R37) [[2]](diffhunk://#diff-7cbdcb6668a2e490a2c4f3e8b40d541cb467566f778979d8690bfbf37e38b107R42-R68)