### PR TITLE
[BUG] Due date UX/UI and logic correction

### DIFF
--- a/frontend/src/components/challenge/TeacherView.jsx
+++ b/frontend/src/components/challenge/TeacherView.jsx
@@ -730,10 +730,12 @@ const TeacherView = ({
                     checked={challengeData?.settings?.dueDateEnabled || false}
                     onChange={async (e) => {
                       try {
+                        const defaultDate = new Date();
+                        defaultDate.setDate(defaultDate.getDate() + 7);
                         const response = await updateDueDate(
                           challengeData._id, 
                           e.target.checked, 
-                          e.target.checked ? (challengeData?.settings?.dueDate || new Date().toISOString().slice(0, 16)) : null
+                          e.target.checked ? (challengeData?.settings?.dueDate || defaultDate.toISOString().slice(0, 16)) : null
                         );
                         setChallengeData(response.challenge);
                         toast.success('Due date settings updated');
@@ -782,8 +784,16 @@ const TeacherView = ({
                   className="btn btn-ghost"
                   onClick={() => setShowDueDateModal(false)}
                 >
-                  Close
+                  Cancel
                 </button>
+                {challengeData?.settings?.dueDateEnabled && (
+                  <button
+                    className="btn btn-primary"
+                    onClick={() => setShowDueDateModal(false)}
+                  >
+                    Update Due Date
+                  </button>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/components/challenge/cards/Challenge1Card.jsx
+++ b/frontend/src/components/challenge/cards/Challenge1Card.jsx
@@ -442,10 +442,12 @@ const TeacherView = ({
                     checked={challengeData?.settings?.dueDateEnabled || false}
                     onChange={async (e) => {
                       try {
+                        const defaultDate = new Date();
+                        defaultDate.setDate(defaultDate.getDate() + 7);
                         const response = await updateDueDate(
                           challengeData._id, 
                           e.target.checked, 
-                          e.target.checked ? (challengeData?.settings?.dueDate || new Date().toISOString().slice(0, 16)) : null
+                          e.target.checked ? (challengeData?.settings?.dueDate || defaultDate.toISOString().slice(0, 16)) : null
                         );
                         setChallengeData(response.challenge);
                         toast.success('Due date settings updated');
@@ -494,8 +496,16 @@ const TeacherView = ({
                   className="btn btn-ghost"
                   onClick={() => setShowDueDateModal(false)}
                 >
-                  Close
+                  Cancel
                 </button>
+                {challengeData?.settings?.dueDateEnabled && (
+                  <button
+                    className="btn btn-primary"
+                    onClick={() => setShowDueDateModal(false)}
+                  >
+                    Update Due Date
+                  </button>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Changes Made

**Fixed default date calculation**
- Replaced `new Date().toISOString().slice(0, 16)` with 7-day future date
- Prevents challenges from being immediately expired on creation

**Improved modal UX**
- Added "Update Due Date" confirmation button when dates are enabled
- Changed "Close" to "Cancel" for clearer action intent

### Root Cause

The original implementation had two issues:

1. **Immediate expiration**: When enabling due dates for the first time, the fallback defaulted to current timestamp, making challenges expired before students could even see them.

2. **UX**: Modal only had a "Close" button with no explicit save action, that makes no sense UX wise and also contributed to the bug. 

Both files had identical modal implementations that needed the same fixes.