### PR TITLE
fix circular dependency issue with getIO for siphonCleanup.js

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -45,12 +45,17 @@ console.log("✅ Socket.IO CORS origin set to:", redirectBase);
 // Initialize Socket.IO with CORS settings
 // This allows the frontend to connect to the Socket.IO server from the specified origin
 
+const { setIO } = require('./utils/io'); // <-- new import
+
 const io = new Server(httpServer, {
   cors: {
     origin: redirectBase,
     methods: ["GET", "POST"]
   }
 });
+
+// register io for other modules
+setIO(io);
 
 // Middleware
 app.use(cors({
@@ -245,7 +250,7 @@ io.on('connection', (socket) => {
   });
 });
 
-// Make io accessible to routes
+// Make io accessible to routes (optional / keep for compatibility)
 app.set('io', io);
 
 // Start Server

--- a/backend/utils/io.js
+++ b/backend/utils/io.js
@@ -1,0 +1,11 @@
+let ioInstance = null;
+
+function setIO(io) {
+  ioInstance = io;
+}
+
+function getIO() {
+  return ioInstance;
+}
+
+module.exports = { setIO, getIO };

--- a/backend/utils/siphonCleanup.js
+++ b/backend/utils/siphonCleanup.js
@@ -6,6 +6,7 @@ const GroupSet = require('../models/GroupSet');
 const Classroom = require('../models/Classroom');
 const { populateNotification } = require('./notifications');
 const mongoose = require('mongoose');
+const { getIO } = require('./io');
 
 const CLEAN_INTERVAL_MS = Number(process.env.SIPHON_CLEAN_INTERVAL_MS || 1 * 60 * 1000); // default: 1 minute
 
@@ -57,8 +58,7 @@ async function cleanupExpiredSiphons() {
 
         // emit realtime if io available
         try {
-          const srv = require('../server');
-          const io = srv?.getIO ? srv.getIO() : srv?.io;
+          const io = getIO && getIO();
           if (io) io.to(`user-${siphon.targetUser}`).emit('notification', populatedTarget);
         } catch (e) {
           // server may not export io; ignore
@@ -87,8 +87,7 @@ async function cleanupExpiredSiphons() {
             const populated = await populateNotification(n._id);
 
             try {
-              const srv = require('../server');
-              const io = srv?.getIO ? srv.getIO() : srv?.io;
+              const io = getIO && getIO();
               if (io) io.to(`user-${memberId}`).emit('notification', populated);
             } catch (e) {}
           } catch (err) {
@@ -98,8 +97,7 @@ async function cleanupExpiredSiphons() {
 
         // Emit group-level update
         try {
-          const srv = require('../server');
-          const io = srv?.getIO ? srv.getIO() : srv?.io;
+          const io = getIO && getIO();
           if (io) io.to(`group-${group._id}`).emit('siphon_update', siphon);
         } catch (e) {}
       }
@@ -119,8 +117,7 @@ async function cleanupExpiredSiphons() {
           });
           const populatedT = await populateNotification(tn._id);
           try {
-            const srv = require('../server');
-            const io = srv?.getIO ? srv.getIO() : srv?.io;
+            const io = getIO && getIO();
             if (io) io.to(`user-${teacherId}`).emit('notification', populatedT);
           } catch (e) {}
         } catch (err) {


### PR DESCRIPTION
This pull request refactors how the Socket.IO instance is shared across backend modules to improve code clarity and modularity. Instead of requiring the main server module to access `io`, a new utility module now manages the Socket.IO instance, which is injected at server startup and accessed elsewhere as needed. This change simplifies dependencies and makes real-time event emission more robust and maintainable.

**Socket.IO Instance Management**

* Introduced a new utility module `backend/utils/io.js` with `setIO` and `getIO` functions to centrally manage the Socket.IO instance. This replaces previous patterns of requiring the server module to access `io`.
* Updated `backend/server.js` to import `setIO` from the new utility and register the `io` instance after initialization, making it accessible to other modules.
* Kept the legacy pattern of attaching `io` to the Express app for compatibility, but clarified its optional use.

**Refactoring Real-Time Event Emission**

* Refactored `backend/utils/siphonCleanup.js` to use the new `getIO` utility for emitting real-time notifications and updates, removing the need to require the server module and improving code modularity. [[1]](diffhunk://#diff-59d63f90b9549a3a55490c1bcde7ba904ab857bdfd8305cf2a8da7ca96ead16dL60-R61) [[2]](diffhunk://#diff-59d63f90b9549a3a55490c1bcde7ba904ab857bdfd8305cf2a8da7ca96ead16dL90-R90) [[3]](diffhunk://#diff-59d63f90b9549a3a55490c1bcde7ba904ab857bdfd8305cf2a8da7ca96ead16dL101-R100) [[4]](diffhunk://#diff-59d63f90b9549a3a55490c1bcde7ba904ab857bdfd8305cf2a8da7ca96ead16dL122-R120)
* Updated imports in `siphonCleanup.js` to use `getIO` from the new utility module.