### PR TITLE
[FEAT] Labels/indicators to show all potential rewards

### DIFF
--- a/frontend/src/components/challenge/RewardsDisplay.jsx
+++ b/frontend/src/components/challenge/RewardsDisplay.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { Coins, Zap, TrendingUp, ShoppingCart, Shield } from 'lucide-react';
+
+const RewardsDisplay = ({ rewards, isDark, isCompleted, size = 'sm' }) => {
+  if (!rewards) return null;
+
+  const hasRewards = rewards.bits > 0 || rewards.multiplier > 0 || rewards.luck > 1.0 || rewards.discount > 0 || rewards.shield || rewards.attackBonus > 0;
+  
+  if (!hasRewards) {
+    return (
+      <div className={`badge badge-outline badge-${size} text-gray-400`}>
+        No rewards
+      </div>
+    );
+  }
+
+  const rewardItems = [];
+
+  if (rewards.bits > 0) {
+    rewardItems.push({
+      icon: <Coins className="w-3 h-3" />,
+      value: rewards.bits,
+      label: 'bits',
+      color: isCompleted ? 'text-green-500' : 'text-yellow-500'
+    });
+  }
+
+  if (rewards.multiplier > 0) {
+    rewardItems.push({
+      icon: <TrendingUp className="w-3 h-3" />,
+      value: `+${(rewards.multiplier * 100).toFixed(0)}%`,
+      label: 'multiplier',
+      color: isCompleted ? 'text-green-500' : 'text-blue-500'
+    });
+  }
+
+  if (rewards.luck > 1.0) {
+    rewardItems.push({
+      icon: <Zap className="w-3 h-3" />,
+      value: `${rewards.luck.toFixed(1)}x`,
+      label: 'luck',
+      color: isCompleted ? 'text-green-500' : 'text-purple-500'
+    });
+  }
+
+  if (rewards.discount > 0) {
+    rewardItems.push({
+      icon: <ShoppingCart className="w-3 h-3" />,
+      value: `${rewards.discount}%`,
+      label: 'discount',
+      color: isCompleted ? 'text-green-500' : 'text-orange-500'
+    });
+  }
+
+  if (rewards.shield) {
+    rewardItems.push({
+      icon: <Shield className="w-3 h-3" />,
+      value: '',
+      label: 'shield',
+      color: isCompleted ? 'text-green-500' : 'text-cyan-500'
+    });
+  }
+
+  if (rewards.attackBonus > 0) {
+    rewardItems.push({
+      icon: <span className="text-red-500">⚔️</span>,
+      value: `+${rewards.attackBonus}`,
+      label: 'attack',
+      color: isCompleted ? 'text-green-500' : 'text-red-500'
+    });
+  }
+
+  if (size === 'lg') {
+    return (
+      <div className="flex flex-wrap gap-2">
+        {rewardItems.map((item, index) => (
+          <div 
+            key={index}
+            className={`badge badge-outline badge-lg gap-1 ${item.color} ${isDark ? 'border-gray-600' : 'border-gray-300'}`}
+          >
+            {item.icon}
+            {item.value && <span className="font-medium">{item.value}</span>}
+            <span className="text-xs opacity-75">{item.label}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (rewardItems.length === 1) {
+    const item = rewardItems[0];
+    return (
+      <div className={`badge badge-outline badge-${size} gap-1 ${item.color} ${isDark ? 'border-gray-600' : 'border-gray-300'}`}>
+        {item.icon}
+        {item.value && <span className="font-medium">{item.value}</span>}
+        <span className="text-xs opacity-75">{item.label}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {rewardItems.map((item, index) => (
+        <div 
+          key={index}
+          className={`badge badge-outline badge-xs gap-1 ${item.color} ${isDark ? 'border-gray-600' : 'border-gray-300'}`}
+        >
+          {item.icon}
+          {item.value && <span className="font-medium">{item.value}</span>}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RewardsDisplay;

--- a/frontend/src/components/challenge/cards/ChallengeCard.jsx
+++ b/frontend/src/components/challenge/cards/ChallengeCard.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Play, Eye, AlertTriangle } from 'lucide-react';
 import { getChallengeColors } from '../../../utils/themeUtils';
-import { calculatePotentialBits } from '../../../utils/challengeUtils';
+import { getRewardDataForChallenge } from '../../../utils/challengeUtils';
 import { unlockHint, startChallenge } from '../../../API/apiChallenge';
-import { CHALLENGE_IDS } from '../../../constants/challengeConstants';
+import { CHALLENGE_IDS, CHALLENGE_NAMES } from '../../../constants/challengeConstants';
+import RewardsDisplay from '../RewardsDisplay';
 import toast from 'react-hot-toast';
 
 const ChallengeCard = ({ 
@@ -29,6 +30,8 @@ const ChallengeCard = ({
   const isChallengeStarted = userChallenge?.currentChallenge === challengeIndex || isCompleted;
   
   const challengeId = CHALLENGE_IDS[challengeIndex];
+  const rewardData = getRewardDataForChallenge(challengeIndex, challengeData, userChallenge, CHALLENGE_NAMES);
+  const challengeRewards = rewardData?.rewards;
   
   const handleUnlockHint = async () => {
     try {
@@ -154,14 +157,17 @@ const ChallengeCard = ({
             {challengeName}
           </div>
           
-          <div className={`badge badge-outline badge-sm w-fit ${
-            userChallenge?.hintsUsed?.[challengeIndex] > 0 ? 'badge-warning' : ''
-          }`}>
-            {calculatePotentialBits(challengeIndex, challengeData, userChallenge)} bits
+          <div className="flex flex-wrap gap-1">
+            <RewardsDisplay 
+              rewards={challengeRewards} 
+              isDark={isDark} 
+              isCompleted={isCompleted}
+              size="sm"
+            />
             {userChallenge?.hintsUsed?.[challengeIndex] > 0 && (
-              <span className="ml-1 text-xs opacity-75">
-                (-{userChallenge.hintsUsed[challengeIndex] * (challengeData?.settings?.hintPenaltyPercent || 25)}%)
-              </span>
+              <div className="badge badge-warning badge-xs">
+                -{userChallenge.hintsUsed[challengeIndex] * (challengeData?.settings?.hintPenaltyPercent || 25)}% hints
+              </div>
             )}
           </div>
         </div>
@@ -182,14 +188,17 @@ const ChallengeCard = ({
             {challengeIcon} {challengeName}
           </span>
           
-          <div className={`badge badge-outline badge-sm ${
-            userChallenge?.hintsUsed?.[challengeIndex] > 0 ? 'badge-warning' : ''
-          }`}>
-            {calculatePotentialBits(challengeIndex, challengeData, userChallenge)} bits
+          <div className="flex items-center gap-2">
+            <RewardsDisplay 
+              rewards={challengeRewards} 
+              isDark={isDark} 
+              isCompleted={isCompleted}
+              size="sm"
+            />
             {userChallenge?.hintsUsed?.[challengeIndex] > 0 && (
-              <span className="ml-1 text-xs opacity-75">
-                (-{userChallenge.hintsUsed[challengeIndex] * (challengeData?.settings?.hintPenaltyPercent || 25)}%)
-              </span>
+              <div className="badge badge-warning badge-xs">
+                -{userChallenge.hintsUsed[challengeIndex] * (challengeData?.settings?.hintPenaltyPercent || 25)}% hints
+              </div>
             )}
           </div>
           
@@ -213,6 +222,26 @@ const ChallengeCard = ({
               </div>
             </div>
           )}
+
+          <div className="bg-base-200 rounded-lg p-3 sm:p-4">
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center gap-2">
+                <span className={`text-sm font-medium ${isDark ? 'text-gray-200' : 'text-gray-700'}`}>Challenge Rewards</span>
+              </div>
+              <RewardsDisplay 
+                rewards={challengeRewards} 
+                isDark={isDark} 
+                isCompleted={isCompleted}
+                size="lg"
+              />
+              {userChallenge?.hintsUsed?.[challengeIndex] > 0 && (
+                <div className="text-xs text-orange-600 dark:text-orange-400">
+                  ⚠️ Hints used: {userChallenge.hintsUsed[challengeIndex]} 
+                  (reducing rewards by {userChallenge.hintsUsed[challengeIndex] * (challengeData?.settings?.hintPenaltyPercent || 25)}%)
+                </div>
+              )}
+            </div>
+          </div>
 
           {challengeData?.settings?.challengeHintsEnabled?.[challengeIndex] && (
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">

--- a/frontend/src/utils/challengeUtils.js
+++ b/frontend/src/utils/challengeUtils.js
@@ -49,7 +49,7 @@ export const getRewardDataForChallenge = (challengeIndex, challengeData, userCha
       }
     }
     rewards.bits = baseBits;
-  } else {  
+  } else {
     if (challengeIndex === 6) { 
       let baseBits = challengeData.settings.totalRewardBits || 0;
       const hintsEnabled = challengeData.settings.challengeHintsEnabled?.[challengeIndex];
@@ -71,7 +71,7 @@ export const getRewardDataForChallenge = (challengeIndex, challengeData, userCha
     if (multiplierReward > 1.0) {
       rewards.multiplier = multiplierReward - 1.0;
     }
-  } else if (challengeIndex === 6) { 
+  } else if (challengeData.settings.multiplierMode === 'total' && challengeIndex === 6) { 
     const totalMultiplier = challengeData.settings.totalMultiplier || 1.0;
     if (totalMultiplier > 1.0) {
       rewards.multiplier = totalMultiplier - 1.0; 
@@ -83,7 +83,7 @@ export const getRewardDataForChallenge = (challengeIndex, challengeData, userCha
     if (luckReward > 1.0) {
       rewards.luck = luckReward;
     }
-  } else if (challengeIndex === 6) { 
+  } else if (challengeData.settings.luckMode === 'total' && challengeIndex === 6) { 
     const totalLuck = challengeData.settings.totalLuck || 1.0;
     if (totalLuck > 1.0) {
       rewards.luck = totalLuck;
@@ -95,7 +95,7 @@ export const getRewardDataForChallenge = (challengeIndex, challengeData, userCha
     if (discountReward > 0) {
       rewards.discount = discountReward;
     }
-  } else if (challengeIndex === 6) { 
+  } else if (challengeData.settings.discountMode === 'total' && challengeIndex === 6) { 
     const totalDiscount = challengeData.settings.totalDiscount || 0;
     if (totalDiscount > 0) {
       rewards.discount = totalDiscount;
@@ -107,7 +107,7 @@ export const getRewardDataForChallenge = (challengeIndex, challengeData, userCha
     if (shieldReward) {
       rewards.shield = true;
     }
-  } else if (challengeIndex === 6) { 
+  } else if (challengeData.settings.shieldMode === 'total' && challengeIndex === 6) { 
     const totalShield = challengeData.settings.totalShield || false;
     if (totalShield) {
       rewards.shield = true;
@@ -119,7 +119,7 @@ export const getRewardDataForChallenge = (challengeIndex, challengeData, userCha
     if (attackReward > 0) {
       rewards.attackBonus = attackReward;
     }
-  } else if (challengeIndex === 6) { 
+  } else if (challengeData.settings.attackMode === 'total' && challengeIndex === 6) { 
     const totalAttackBonus = challengeData.settings.totalAttackBonus || 0;
     if (totalAttackBonus > 0) {
       rewards.attackBonus = totalAttackBonus;


### PR DESCRIPTION
This introduces a simple fetch from the `challenge` backend to show _all_ potential awards of a given challenge as opposed to just the bits.