### PR TITLE
refactor: enhance support FAQ with item redemption process for students

### DIFF
--- a/backend/routes/challenge/utils.js
+++ b/backend/routes/challenge/utils.js
@@ -97,9 +97,9 @@ function calculateChallengeRewards(user, challenge, challengeIndex, userChalleng
       const challengeName = CHALLENGE_NAMES[challengeIndex] || `Challenge ${challengeIndex + 1}`;
       
       const transactionDescription = usedHints > 0 
-        ? `Completed ${challengeName} (${baseBits} - ${baseBits - bitsAwarded} hint penalty)`
-        : `Completed ${challengeName}`;
-        
+        ? `Completed Challenge: ${challengeName} (${baseBits} - ${baseBits - bitsAwarded} hint penalty)`
+        : `Completed Challenge: ${challengeName}`;
+
       user.transactions = user.transactions || [];
       user.transactions.push({
         amount: bitsAwarded,

--- a/frontend/src/pages/Support.jsx
+++ b/frontend/src/pages/Support.jsx
@@ -215,6 +215,15 @@ const Support = () => {
             "• Some items may be non-refundable"
           ],
           role: ["student"]
+        },
+        {
+          question: "How are items purchased from the Bazaar redeemed/activated?",
+          answer: [
+            "• Items that grant active effects (Attack, Defend, Utility, Discount, etc.) must be redeemed from the Inventory section of the Bazaar.",
+            "• Open the Bazaar page, click Show Inventory, find the purchased item and click \"Use\" to activate its effect.",
+            "• Note that passive items without specified effects, such as extra credit items, should be presented to the teacher or relevant party for redemption."
+          ],
+          role: ["student"]
         }
       ]
     },


### PR DESCRIPTION
This pull request introduces a minor update to the challenge completion transaction description and expands the support documentation for Bazaar item redemption. The main changes clarify user-facing messages and provide additional guidance for students.

User-facing message improvements:

* Updated the transaction description in `calculateChallengeRewards` to use the format "Completed Challenge: {challengeName}" for clarity and consistency.

Support documentation enhancements:

* Added a new FAQ entry to the Support page explaining how students can redeem or activate items purchased from the Bazaar, including instructions for both active and passive items.