### PR TITLE
refactor: remove redundant quotes from quotes data file

### DIFF
--- a/backend/data/quotes.txt
+++ b/backend/data/quotes.txt
@@ -1,6 +1,5 @@
 The only way to do great work is to love what you do.|Steve Jobs
 Innovation distinguishes between a leader and a follower.|Steve Jobs
-Code is poetry.|Unknown
 The best error message is the one that never shows up.|Thomas Fuchs
 Talk is cheap. Show me the code.|Linus Torvalds
 Programs must be written for people to read.|Harold Abelson
@@ -16,21 +15,15 @@ A CD. How quaint. We have these in Museums.|Eoin Colfer
 I have never let my schooling interfere with my education.|Mark Twain
 Technological progress has merely provided us with more efficient means for going backwards.|Aldous Huxley
 It's supposed to be automatic, but actually you have to push this button.|John Brunner
-The purpose of technology is to make people more efficient so they can live more fulfilling lives.|Elon Musk
 Technology is best when it brings people together.|Matt Mullenweg
 The computer is like an ethereal machine that only you can operate.|Kurt Vonnegut
 The future is already here—it's just not very evenly distributed.|William Gibson
 Technology is a word that describes something that doesn't work yet.|Douglas Adams
-Success is not final, failure is not fatal: it is the courage to continue that counts.|Winston Churchill
 The way to get started is to quit talking and begin doing.|Walt Disney
 Don't let yesterday take up too much of today.|Will Rogers
-You learn more from failure than from success.|Unknown
 It's not whether you get knocked down, it's whether you get up.|Vince Lombardi
 Believe you can and you're halfway there.|Theodore Roosevelt
 The only impossible journey is the one you never begin.|Tony Robbins
-Success is walking from failure to failure with no loss of enthusiasm.|Winston Churchill
-Your limitation—it's only your imagination.|Unknown
-Push yourself, because no one else is going to do it for you.|Unknown
 Life is what happens to you while you're busy making other plans.|John Lennon
 The future belongs to those who believe in the beauty of their dreams.|Eleanor Roosevelt
 It is during our darkest moments that we must focus to see the light.|Aristotle
@@ -97,6 +90,5 @@ The only way to do great work is to love what you do.|Steve Jobs
 Do one thing every day that scares you.|Eleanor Roosevelt
 Believe in yourself and all that you are.|Christian D. Larson
 Limit your 'always' and your 'nevers'.|Amy Poehler
-Act as if what you want is already true.|Unknown
 Don’t wish it were easier. Wish you were better.|Jim Rohn
 Whether you think you can or you think you can’t, you’re right.|Henry Ford


### PR DESCRIPTION
This pull request cleans up the `backend/data/quotes.txt` file by removing several motivational and technology-related quotes, many of which were either generic or attributed to "Unknown". The main goal is to streamline the content and focus the collection on more relevant or notable entries.

Quotes removed for focus and relevance:

* Removed generic motivational quotes such as "Success is not final, failure is not fatal: it is the courage to continue that counts.", "You learn more from failure than from success.", and "Push yourself, because no one else is going to do it for you."
* Removed technology-related quotes that were less impactful or from less notable sources, including "Code is poetry." and "The purpose of technology is to make people more efficient so they can live more fulfilling lives." [[1]](diffhunk://#diff-6d021897ee245aaae487dcb5b6b516afab2be69a572b701cbbbbaab535a98241L3) [[2]](diffhunk://#diff-6d021897ee245aaae487dcb5b6b516afab2be69a572b701cbbbbaab535a98241L19-L33)
* Removed the quote "Act as if what you want is already true." to further refine the collection.