### PR TITLE
refactor: update multiplier logic to add only excess over 1.0 for bulk assignments

### DIFF
--- a/backend/routes/groupBalance.js
+++ b/backend/routes/groupBalance.js
@@ -198,10 +198,10 @@ router.post(
           // NEW additive logic
           let finalMultiplier;
           if (numericAmount > 0) {
-            finalMultiplier = 0;
-            if (applyGroupMultipliers) finalMultiplier += (group.groupMultiplier || 0);
-            if (applyPersonalMultipliers) finalMultiplier += (user.passiveAttributes?.multiplier || 0);
-            if (finalMultiplier === 0) finalMultiplier = 1;
+            // Start from base 1 and add only the extra above 1.0 from each source
+            finalMultiplier = 1;
+            if (applyGroupMultipliers) finalMultiplier += ((group.groupMultiplier || 1) - 1);
+            if (applyPersonalMultipliers) finalMultiplier += ((user.passiveAttributes?.multiplier || 1) - 1);
           } else {
             finalMultiplier = 1;
           }

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -107,13 +107,12 @@ router.post('/assign/bulk', ensureAuthenticated, async (req, res) => {
       //   }
       // }
 
-      // NEW additive logic
+      // NEW additive logic (only add excess over 1.0)
       let finalMultiplier;
       if (numericAmount >= 0) {
-        finalMultiplier = 0;
-        if (applyGroupMultipliers) finalMultiplier += (groupMultiplier || 0);
-        if (applyPersonalMultipliers) finalMultiplier += (passiveMultiplier || 0);
-        if (finalMultiplier === 0) finalMultiplier = 1;
+        finalMultiplier = 1;
+        if (applyGroupMultipliers) finalMultiplier += ((groupMultiplier || 1) - 1);
+        if (applyPersonalMultipliers) finalMultiplier += ((passiveMultiplier || 1) - 1);
       } else {
         finalMultiplier = 1;
       }

--- a/backend/routes/wallet.js
+++ b/backend/routes/wallet.js
@@ -425,10 +425,9 @@ router.post('/assign/bulk', ensureAuthenticated, async (req, res) => {
       // NEW additive logic
       let finalMultiplier;
       if (numericAmount >= 0) {
-        finalMultiplier = 0;
-        if (applyGroupMultipliers) finalMultiplier += (groupMultiplier || 0);
-        if (applyPersonalMultipliers) finalMultiplier += (passiveMultiplier || 0);
-        if (finalMultiplier === 0) finalMultiplier = 1; // fallback to no-op
+        finalMultiplier = 1;
+        if (applyGroupMultipliers) finalMultiplier += ((groupMultiplier || 1) - 1);
+        if (applyPersonalMultipliers) finalMultiplier += ((passiveMultiplier || 1) - 1);
       } else {
         finalMultiplier = 1;
       }


### PR DESCRIPTION
This pull request updates the logic for calculating multipliers in three backend routes to ensure additive behavior only applies to the excess above the base value of 1.0. Instead of starting from zero and summing all multipliers, the new approach starts from one and adds only the amount above one from each source, which prevents unintended inflation when multipliers are not set.

Multiplier calculation logic updates:

* In `backend/routes/groupBalance.js`, the multiplier calculation for positive amounts now starts from 1 and only adds the extra above 1.0 from both group and personal multipliers.
* In `backend/routes/users.js` (`/assign/bulk` route), the same additive logic is applied: multipliers start from 1, and only the excess above 1.0 from group and personal multipliers is added for non-negative amounts.
* In `backend/routes/wallet.js` (`/assign/bulk` route), the multiplier logic is similarly updated to start from 1 and add only the excess above 1.0 from each multiplier, ensuring consistent behavior across routes.