### PR TITLE
feat(recent stat changes): enhance messages with full names

### DIFF
--- a/backend/routes/classroom.js
+++ b/backend/routes/classroom.js
@@ -1144,6 +1144,8 @@ router.patch('/:classId/users/:userId/stats', ensureAuthenticated, async (req, r
     };
 
     // Notify the student (targeted notification). Keep this simple & readable for the student.
+    const fullName = `${student.firstName || ''} ${student.lastName || ''}`.trim() || student.email;
+
     const studentNotification = await Notification.create({
       user: student._id,
       actionBy: req.user._id,
@@ -1165,7 +1167,7 @@ router.patch('/:classId/users/:userId/stats', ensureAuthenticated, async (req, r
         user: classroom.teacher, // teacher receives the change record
         actionBy: req.user._id,
         type: 'stats_adjusted',
-        message: `Updated stats for ${student.firstName || student.email}: ${formatChangeSummary(changes) || ''}`,
+        message: `Updated stats for ${fullName}: ${formatChangeSummary(changes) || ''}`,
         targetUser: student._id,
         changes,
         classroom: classId,

--- a/frontend/src/pages/People.jsx
+++ b/frontend/src/pages/People.jsx
@@ -1713,7 +1713,13 @@ const visibleCount = filteredStudents.length;
                             })()}
                           </div>
                           <div className="font-medium">
-                            {s.targetUser ? (s.targetUser.firstName || s.targetUser.email) : 'Unknown user'}
+                            {s.targetUser
+                              ? (
+                                  `${(s.targetUser.firstName || '').trim()} ${(s.targetUser.lastName || '').trim()}`.trim()
+                                  || s.targetUser.email
+                                )
+                              : 'Unknown user'
+                            }
                           </div>
                           <div className="mt-1">
                             {Array.isArray(s.changes) && s.changes.length ? (


### PR DESCRIPTION
This pull request improves how student names are displayed in both backend notifications and the frontend user interface. The main change is a consistent formatting of student names, showing both first and last names when available, and falling back to email if necessary.

**Backend notification improvements:**

* Consistently formats student names in notifications by combining `firstName` and `lastName`, or falling back to email if names are missing. (`backend/routes/classroom.js`)
* Updates the teacher notification message to use the new formatted student name instead of just `firstName` or email. (`backend/routes/classroom.js`)

**Frontend display improvements:**

* Updates the student name display in the people list to use the same full name logic, improving clarity and consistency for users. (`frontend/src/pages/People.jsx`)