### PR TITLE
feat(recent stat changes): enhance messages with full names

### DIFF
--- a/backend/routes/classroom.js
+++ b/backend/routes/classroom.js
@@ -1144,6 +1144,8 @@ router.patch('/:classId/users/:userId/stats', ensureAuthenticated, async (req, r
     };
 
     // Notify the student (targeted notification). Keep this simple & readable for the student.
+    const fullName = `${student.firstName || ''} ${student.lastName || ''}`.trim() || student.email;
+
     const studentNotification = await Notification.create({
       user: student._id,
       actionBy: req.user._id,
@@ -1165,7 +1167,7 @@ router.patch('/:classId/users/:userId/stats', ensureAuthenticated, async (req, r
         user: classroom.teacher, // teacher receives the change record
         actionBy: req.user._id,
         type: 'stats_adjusted',
-        message: `Updated stats for ${student.firstName || student.email}: ${formatChangeSummary(changes) || ''}`,
+        message: `Updated stats for ${fullName}: ${formatChangeSummary(changes) || ''}`,
         targetUser: student._id,
         changes,
         classroom: classId,

--- a/frontend/src/pages/People.jsx
+++ b/frontend/src/pages/People.jsx
@@ -1713,7 +1713,13 @@ const visibleCount = filteredStudents.length;
                             })()}
                           </div>
                           <div className="font-medium">
-                            {s.targetUser ? (s.targetUser.firstName || s.targetUser.email) : 'Unknown user'}
+                            {s.targetUser
+                              ? (
+                                  `${(s.targetUser.firstName || '').trim()} ${(s.targetUser.lastName || '').trim()}`.trim()
+                                  || s.targetUser.email
+                                )
+                              : 'Unknown user'
+                            }
                           </div>
                           <div className="mt-1">
                             {Array.isArray(s.changes) && s.changes.length ? (


### PR DESCRIPTION
This pull request improves the way student names are displayed in notifications and the UI by consistently showing the full name (first and last) when available, and falling back to the email address if necessary. This enhances clarity for both teachers and students when stats are updated.

**Notification and display improvements:**

* Backend: Updated the notification logic in `backend/routes/classroom.js` to use the student's full name (first and last) or email in messages sent to both students and teachers. [[1]](diffhunk://#diff-8bf345992946eeb9598dd5399e3e47d65810ebe445fdec3288d11c8cf80862f6R1147-R1148) [[2]](diffhunk://#diff-8bf345992946eeb9598dd5399e3e47d65810ebe445fdec3288d11c8cf80862f6L1168-R1170)
* Frontend: Modified the student name rendering in `frontend/src/pages/People.jsx` to show the full name (first and last) when available, otherwise falling back to the email.