### PR TITLE
Add siphon history retrieval and enhance support FAQ for teachers

### DIFF
--- a/backend/routes/siphon.js
+++ b/backend/routes/siphon.js
@@ -454,7 +454,7 @@ router.post('/:id/teacher-approve', ensureAuthenticated, async (req, res) => {
       return cb ? cb.balance : (user.balance || 0);
     };
 
-    const targetUser = await User.findById(siphon.targetUser._id).select('balance classroomBalances');
+    const targetUser = await User.findById(siphon.targetUser._id).select('balance classroomBalances firstName lastName email');
     const currentBalance = getClassroomBalance(targetUser, classroomId);
 
     // Use the stored percentage to compute the actual amount now
@@ -480,7 +480,7 @@ router.post('/:id/teacher-approve', ensureAuthenticated, async (req, res) => {
       // Get group and classroom info for notifications
       const group = await Group.findById(siphon.group._id).populate('members._id', '_id status email firstName lastName');
       const classroom = await Classroom.findById(classroomId).select('name teacher');
-      const targetName = `${siphon.targetUser.firstName || ''} ${siphon.targetUser.lastName || ''}`.trim() || siphon.targetUser.email;
+      const targetName = `${targetUser.firstName || ''} ${targetUser.lastName || ''}`.trim() || targetUser.email;
 
       // 1. Notify target
       const targetNotif = await Notification.create({
@@ -573,7 +573,7 @@ router.post('/:id/teacher-approve', ensureAuthenticated, async (req, res) => {
     });
 
     // Create enhanced notifications with more details
-    const targetName = `${siphon.targetUser.firstName || ''} ${siphon.targetUser.lastName || ''}`.trim() || siphon.targetUser.email;
+    const targetName = `${targetUser.firstName || ''} ${targetUser.lastName || ''}`.trim() || targetUser.email;
     const amountPerRecipient = Math.floor(finalSiphonAmount / recipients.length);
     const groupName = siphon.group.name;
     const groupSetName = groupSetInfo?.name || 'Unknown GroupSet';
@@ -668,6 +668,45 @@ router.post('/:id/teacher-approve', ensureAuthenticated, async (req, res) => {
   } catch (err) {
     console.error('Siphon approval error:', err);
     res.status(500).json({ error: 'Approval failed: ' + err.message });
+  }
+});
+
+// GET all siphon history for a classroom (teacher/admin only)
+router.get('/classroom/:classroomId/history', ensureAuthenticated, async (req, res) => {
+  try {
+    const { classroomId } = req.params;
+
+    // Permission: must be teacher or classroom-scoped admin
+    const classroom = await Classroom.findById(classroomId).select('teacher');
+    if (!classroom) return res.status(404).json({ error: 'Classroom not found' });
+
+    const isTeacherOfClass = String(classroom.teacher) === String(req.user._id);
+    const isClassAdmin = await isClassroomAdmin(req.user, classroomId);
+    if (!isTeacherOfClass && !isClassAdmin) {
+      return res.status(403).json({ error: 'Not authorized' });
+    }
+
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const perPage = Math.min(100, Math.max(1, parseInt(req.query.perPage) || 20));
+    const skip = (page - 1) * perPage;
+
+    const [total, siphons] = await Promise.all([
+      SiphonRequest.countDocuments({ classroom: classroomId }),
+      SiphonRequest.find({ classroom: classroomId })
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(perPage)
+        .populate('requestedBy', 'firstName lastName email')
+        .populate('targetUser', 'firstName lastName email')
+        .populate('group', 'name')
+        .populate('votes.user', 'firstName lastName email')
+        .lean()
+    ]);
+
+    res.json({ siphons, total, page, perPage });
+  } catch (err) {
+    console.error('Siphon history error:', err);
+    res.status(500).json({ error: 'Failed to load siphon history' });
   }
 });
 

--- a/frontend/src/pages/Groups.jsx
+++ b/frontend/src/pages/Groups.jsx
@@ -99,6 +99,13 @@ const Groups = () => {
   const [now, setNow] = useState(Date.now());
   const [memberEquippedBadges, setMemberEquippedBadges] = useState({}); // { odierI: badge }
 
+  // Siphon history (teacher-only tab)
+  const [siphonHistory, setSiphonHistory] = useState([]);
+  const [siphonHistoryTotal, setSiphonHistoryTotal] = useState(0);
+  const [siphonHistoryPage, setSiphonHistoryPage] = useState(1);
+  const [siphonHistoryLoading, setSiphonHistoryLoading] = useState(false);
+  const SIPHON_HISTORY_PER_PAGE = 20;
+
   useEffect(() => {
     const t = setInterval(() => setNow(Date.now()), 1000); // update every second for countdown
     return () => clearInterval(t);
@@ -744,6 +751,31 @@ const Groups = () => {
     }
   };
 
+  // Fetch siphon history for the classroom (teacher-only)
+  const fetchSiphonHistory = async (page = 1) => {
+    if (!id) return;
+    setSiphonHistoryLoading(true);
+    try {
+      const res = await axios.get(`/api/siphon/classroom/${id}/history`, {
+        params: { page, perPage: SIPHON_HISTORY_PER_PAGE }
+      });
+      setSiphonHistory(res.data.siphons);
+      setSiphonHistoryTotal(res.data.total);
+      setSiphonHistoryPage(page);
+    } catch (err) {
+      toast.error(err.response?.data?.error || 'Failed to load siphon history');
+    } finally {
+      setSiphonHistoryLoading(false);
+    }
+  };
+
+  // Load siphon history whenever the tab becomes active
+  useEffect(() => {
+    if (activeTab === 'history' && (user?.role === 'teacher' || canManageGroups)) {
+      fetchSiphonHistory(1);
+    }
+  }, [activeTab]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Open the adjustment modal for a specific groupSet and group
   const openAdjustModal = (groupSetId, groupId) => {
     const group = groupSets.find(gs => gs._id === groupSetId)?.groups.find(g => g._id === groupId);
@@ -983,6 +1015,156 @@ const Groups = () => {
             >
               Create
             </a>
+            <a
+              role="tab"
+              className={`tab ${activeTab === 'history' ? 'tab-active' : ''}`}
+              onClick={() => setActiveTab('history')}
+            >
+              Siphon History
+            </a>
+          </div>
+        )}
+
+        {/* Siphon History Tab */}
+        {(user.role === 'teacher' || canManageGroups) && activeTab === 'history' && (
+          <div className="card bg-base-100 shadow-md p-4 mb-6">
+            <h2 className="text-xl font-semibold mb-4">Siphon History</h2>
+            {siphonHistoryLoading ? (
+              <div className="flex justify-center py-8"><span className="loading loading-spinner loading-md" /></div>
+            ) : siphonHistory.length === 0 ? (
+              <p className="text-base-content/60 text-sm">No siphon requests found for this classroom.</p>
+            ) : (
+              <>
+                <div className="overflow-x-auto">
+                  <table className="table table-zebra w-full text-sm">
+                    <thead>
+                      <tr>
+                        <th>Date</th>
+                        <th>Group</th>
+                        <th>Requested By</th>
+                        <th>Target</th>
+                        <th>Amount</th>
+                        <th>Votes</th>
+                        <th>Status</th>
+                        <th>Proof</th>
+                        <th>Details</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {siphonHistory.map(s => {
+                        const yesVotes = s.votes?.filter(v => v.vote === 'yes') || [];
+                        const noVotes  = s.votes?.filter(v => v.vote === 'no')  || [];
+                        const requesterName = s.requestedBy
+                          ? `${s.requestedBy.firstName || ''} ${s.requestedBy.lastName || ''}`.trim() || s.requestedBy.email
+                          : '—';
+                        const targetName = s.targetUser
+                          ? `${s.targetUser.firstName || ''} ${s.targetUser.lastName || ''}`.trim() || s.targetUser.email
+                          : '—';
+                        const groupName = s.group?.name || '—';
+                        const statusBadge = {
+                          pending:          <span className="badge badge-warning badge-sm">Pending</span>,
+                          group_approved:   <span className="badge badge-info badge-sm">Group Approved</span>,
+                          teacher_approved: <span className="badge badge-success badge-sm">Approved</span>,
+                          rejected:         <span className="badge badge-error badge-sm">Rejected</span>,
+                          expired:          <span className="badge badge-ghost badge-sm">Expired</span>,
+                        }[s.status] || <span className="badge badge-ghost badge-sm">{s.status}</span>;
+                        const amountStr = s.executedAmount != null
+                          ? s.requestedPercent != null
+                            ? `${s.requestedPercent}% (${s.executedAmount} bits executed)`
+                            : `${s.executedAmount} bits (executed)`
+                          : s.requestedPercent != null
+                            ? `${s.requestedPercent}% (≈${s.amount} bits at submission)`
+                            : `${s.amount} bits`;
+
+                        return (
+                          <tr key={s._id}>
+                            <td className="whitespace-nowrap">
+                              {new Date(s.createdAt).toLocaleString()}
+                            </td>
+                            <td>{groupName}</td>
+                            <td title={s.requestedBy?.email}>{requesterName}</td>
+                            <td title={s.targetUser?.email}>{targetName}</td>
+                            <td className="whitespace-nowrap">{amountStr}</td>
+                            <td>
+                              <div className="flex gap-2">
+                                <span className="badge badge-success badge-sm">{yesVotes.length} YES</span>
+                                <span className="badge badge-error badge-sm">{noVotes.length} NO</span>
+                              </div>
+                              {s.votes?.length > 0 && (
+                                <details className="mt-1">
+                                  <summary className="text-xs cursor-pointer text-base-content/60">voter breakdown</summary>
+                                  <ul className="text-xs mt-1 space-y-0.5">
+                                    {s.votes.map((v, i) => {
+                                      const vName = v.user
+                                        ? `${v.user.firstName || ''} ${v.user.lastName || ''}`.trim() || v.user.email
+                                        : '?';
+                                      return (
+                                        <li key={i} className={v.vote === 'yes' ? 'text-success' : 'text-error'}>
+                                          {vName}: {v.vote.toUpperCase()}
+                                        </li>
+                                      );
+                                    })}
+                                  </ul>
+                                </details>
+                              )}
+                            </td>
+                            <td>{statusBadge}</td>
+                            <td>
+                              {s.proof?.storedName ? (
+                                <a
+                                  href={`/api/siphon/${s._id}/proof`}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="btn btn-xs btn-outline"
+                                >
+                                  {s.proof.originalName || 'View'}
+                                </a>
+                              ) : (
+                                <span className="text-base-content/40 text-xs">None</span>
+                              )}
+                            </td>
+                            <td>
+                              <details>
+                                <summary className="btn btn-xs btn-ghost cursor-pointer">Reason</summary>
+                                <div
+                                  className="prose prose-sm max-w-xs mt-1 p-2 bg-base-200 rounded text-xs"
+                                  dangerouslySetInnerHTML={{ __html: s.reasonHtml }}
+                                />
+                              </details>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+
+                {/* Pagination */}
+                {siphonHistoryTotal > SIPHON_HISTORY_PER_PAGE && (
+                  <div className="flex justify-between items-center mt-4 text-sm">
+                    <span className="text-base-content/60">
+                      {siphonHistoryTotal} total — page {siphonHistoryPage} of {Math.ceil(siphonHistoryTotal / SIPHON_HISTORY_PER_PAGE)}
+                    </span>
+                    <div className="flex gap-2">
+                      <button
+                        className="btn btn-xs btn-outline"
+                        disabled={siphonHistoryPage <= 1}
+                        onClick={() => fetchSiphonHistory(siphonHistoryPage - 1)}
+                      >
+                        ← Prev
+                      </button>
+                      <button
+                        className="btn btn-xs btn-outline"
+                        disabled={siphonHistoryPage >= Math.ceil(siphonHistoryTotal / SIPHON_HISTORY_PER_PAGE)}
+                        onClick={() => fetchSiphonHistory(siphonHistoryPage + 1)}
+                      >
+                        Next →
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
           </div>
         )}
 

--- a/frontend/src/pages/Support.jsx
+++ b/frontend/src/pages/Support.jsx
@@ -355,7 +355,7 @@ const Support = () => {
           answer: [
             "• Items that grant active effects (Attack, Defend, Utility, Discount, etc.) must be redeemed from the Inventory section of the Bazaar.",
             "• Open the Bazaar page, click **Inventory**, find the purchased item and equip/use it to activate its effect.",
-            "• Note that passive items without specified effects, such as extra credit items, should be presented to the teacher or relevant party for redemption."
+            "• Note that passive items without specified effects, such as extra credit items, should be presented to the teacher or relevant party for redemption. Redeeming through the Inventory is only necessary for items with active effects that impact stats or interactions within the system."
           ],
           role: ["student"]
         }
@@ -479,6 +479,25 @@ const Support = () => {
             "**Workaround:** A group member can submit another siphon against the frozen user and then vote NO (majority). This forces the system to unfreeze the account."
           ],
           role: ["all"]
+        },
+        {
+          question: "Are siphon records maintained and accessible for transparency/revision?",
+          answer: [
+            "Yes! Teachers — and Admin/TAs with the **Group Management** permission enabled by the teacher — can view the full siphon history for a classroom.",
+            "",
+            "**To view siphon history:**",
+            "• Go to the **Groups** page within the classroom",
+            "• Look for the **Siphon History** section (visible to teachers and permitted Admin/TAs)",
+            "",
+            "**What siphon history shows:**",
+            "• The targeted (siphoned) member and the group involved",
+            "• Which members voted, and how they voted (Yes/No)",
+            "• The outcome (e.g. approved, rejected, expired, or cancelled)",
+            "• Timestamps for when the request was created and resolved",
+            "",
+            "This gives teachers and Admin/TAs full visibility into group accountability actions and helps monitor for any misuse of the siphon system."
+          ],
+          role: ["teacher", "admin"]
         }
       ]
     },


### PR DESCRIPTION
This pull request introduces a new feature that allows teachers and classroom admins to view the full history of "siphon" requests for a classroom, enhancing transparency and accountability. It includes backend API additions, frontend UI updates to display the siphon history with pagination, and support documentation improvements to explain this feature to users.

**Backend API enhancements:**

* Added a new route `GET /api/siphon/classroom/:classroomId/history` to return paginated siphon request history for a classroom, accessible only to teachers or classroom-scoped admins. This endpoint includes detailed user and group information for each siphon.
* Updated notification and name resolution logic in the siphon approval flow to use the latest user information by querying `targetUser` directly, ensuring accurate display of names and emails. [[1]](diffhunk://#diff-828dac939f9db0e9e2a72e0ecc60ab6dde4207d4b9c0161d0172f0e2192597e3L457-R457) [[2]](diffhunk://#diff-828dac939f9db0e9e2a72e0ecc60ab6dde4207d4b9c0161d0172f0e2192597e3L483-R483) [[3]](diffhunk://#diff-828dac939f9db0e9e2a72e0ecc60ab6dde4207d4b9c0161d0172f0e2192597e3L576-R576)

**Frontend UI updates:**

* Added state and logic in `Groups.jsx` to fetch, store, and paginate siphon history for the active classroom. The history is loaded when the relevant tab is selected by a teacher or authorized admin. [[1]](diffhunk://#diff-9729c9b6ccd6a36233c7da53586144b0dddc43958e6a02b15c4879df093b8669R102-R108) [[2]](diffhunk://#diff-9729c9b6ccd6a36233c7da53586144b0dddc43958e6a02b15c4879df093b8669R754-R778)
* Introduced a new "Siphon History" tab in the Groups page, visible only to teachers and permitted admins, displaying a detailed table of all siphon requests with information on group, participants, votes, status, and proof files. Includes pagination and breakdown of voter decisions.

**Support documentation:**

* Updated the Support page to clarify the process for redeeming items in the Bazaar, distinguishing between active and passive items.
* Added a new FAQ entry explaining the existence of siphon history, who can access it, and what information it provides for transparency and revision purposes.