### PR TITLE
feat: add classroom-scoped admin check in Profile component and update order retrieval logic

### DIFF
--- a/backend/routes/bazaar.js
+++ b/backend/routes/bazaar.js
@@ -9,7 +9,7 @@ const { ensureAuthenticated } = require('../config/auth');
 const router = express.Router();
 const Order = require('../models/Order');
 const blockIfFrozen = require('../middleware/blockIfFrozen');
-const { getScopedUserStats } = require('../utils/classroomStats'); // ADD
+const { getScopedUserStats, isClassroomAdmin } = require('../utils/classroomStats'); // ADD
 const upload = require('../middleware/upload'); // reuse existing upload middleware
 
 // Middleware: Only teachers allowed for certain actions
@@ -973,9 +973,13 @@ router.get('/user/:userId/balance', async (req, res) => {
 router.get('/orders/user/:userId', ensureAuthenticated, async (req, res) => {
   try {
     const { userId } = req.params;
+    const { classroomId } = req.query;
 
-    // Only the user themself, teachers, or admins may proceed
-    if (req.user._id.toString() !== userId && !['teacher', 'admin'].includes(req.user.role)) {
+    // Determine if the requester is a classroom-scoped admin/TA
+    const isClassAdmin = classroomId ? await isClassroomAdmin(req.user, classroomId) : false;
+
+    // Only the user themself, teachers, global admins, or classroom-scoped admin/TA may proceed
+    if (req.user._id.toString() !== userId && !['teacher', 'admin'].includes(req.user.role) && !isClassAdmin) {
       return res.status(403).json({ error: 'Not authorized' });
     }
 
@@ -1043,6 +1047,32 @@ router.get('/orders/user/:userId', ensureAuthenticated, async (req, res) => {
            return classroomId && adminClassroomIds.some(acId => acId.equals(classroomId));
          })
        );
+
+    // CLASSROOM ADMIN/TA: allow viewing only orders from the specific classroom
+    } else if (isClassAdmin && req.user._id.toString() !== userId) {
+      const mongoose = require('mongoose');
+      const classroomObjId = new mongoose.Types.ObjectId(classroomId);
+
+      const allOrders = await Order.find({ user: userId })
+        .populate('items')
+        .populate({
+          path: 'items',
+          populate: {
+            path: 'bazaar',
+            populate: {
+              path: 'classroom',
+              select: '_id name code'
+            }
+          }
+        })
+        .sort({ createdAt: -1 });
+
+      orders = allOrders.filter(order =>
+        order.items.some(item => {
+          const cId = item.bazaar?.classroom?._id;
+          return cId && cId.equals(classroomObjId);
+        })
+      );
 
      } else {
       // Self (student) or admin/teacher viewing own orders: return all orders for that user

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -64,6 +64,8 @@ export default function Profile() {
   const [sortField, setSortField] = useState('date');
   const [sortDirection, setSortDirection] = useState('desc');
   const [stats, setStats] = useState({});
+  // Whether the currently logged-in user is a classroom-scoped admin/TA for this classroom
+  const [isViewerClassroomAdmin, setIsViewerClassroomAdmin] = useState(false);
 
   // Edit profile state (restore edit/avatar functionality)
   const [editing, setEditing] = useState(false);
@@ -180,6 +182,26 @@ export default function Profile() {
     return () => { mounted = false; };
   }, [profile, classroomId, profileId]);
 
+  // Detect whether the currently logged-in user is a classroom-scoped admin/TA
+  useEffect(() => {
+    if (!classroomId || !user) { setIsViewerClassroomAdmin(false); return; }
+    // Teachers are implicitly allowed; no need for extra check
+    if (user.role === 'teacher') { setIsViewerClassroomAdmin(false); return; }
+    let mounted = true;
+    (async () => {
+      try {
+        const res = await axios.get(`/api/classroom/${classroomId}/students`, { withCredentials: true });
+        if (!mounted) return;
+        const students = Array.isArray(res.data) ? res.data : [];
+        const me = students.find(s => String(s._id) === String(user._id));
+        setIsViewerClassroomAdmin(!!(me?.isClassroomAdmin));
+      } catch {
+        if (mounted) setIsViewerClassroomAdmin(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, [classroomId, user]);
+
   // Added new useEffect to fetch the stats into a table.
   useEffect(() => {
       // Allow teachers and classroom-scoped Admin/TAs to view a student's purchase history
@@ -187,16 +209,19 @@ export default function Profile() {
         let allowed = false;
         if (user?.role === 'teacher') allowed = true;
         else if (user?.role === 'admin') {
-          // Allow admin to request orders; server will only return orders from classrooms
-          // where the admin is authorized (per-classroom admins). This lets the UI show
-          // the same "All Classrooms" behavior but scoped server-side.
+          // Allow global admin to request orders; server will filter by authorized classrooms
+          allowed = true;
+        } else if (isViewerClassroomAdmin && classroomId) {
+          // Classroom-scoped admin/TA: allowed for this specific classroom
           allowed = true;
         }
         if (allowed && profile?.role === 'student') {
+          // Pass classroomId for classroom-scoped admin/TA so the server can scope results
+          const url = (isViewerClassroomAdmin && classroomId && user?.role !== 'teacher' && user?.role !== 'admin')
+            ? `/api/bazaar/orders/user/${profileId}?classroomId=${classroomId}`
+            : `/api/bazaar/orders/user/${profileId}`;
           axios
-            .get(`/api/bazaar/orders/user/${profileId}`, {
-              withCredentials: true
-            })
+            .get(url, { withCredentials: true })
             .then(res => {
               // Keep only orders with items (exclude zero‑item mystery-box opens)
               const validOrders = (res.data || []).filter(order => order.items && order.items.length > 0);
@@ -209,7 +234,7 @@ export default function Profile() {
             });
         }
       })();
-   }, [profile, user?.role, profileId, classroomId]);
+   }, [profile, user?.role, profileId, classroomId, isViewerClassroomAdmin]);
 
   // Fetch additional stats about the profile (e.g., balances, activity)
   useEffect(() => {
@@ -793,7 +818,7 @@ export default function Profile() {
                    />
                   </div>
  
-                  {( (user?.role === 'teacher') || (user?.role === 'admin') ) && profile?.role === 'student' && (
+                  {( (user?.role === 'teacher') || (user?.role === 'admin') || isViewerClassroomAdmin ) && profile?.role === 'student' && (
                         <div className="mt-6">
                             <h2 className="text-xl mb-2">
                                 Purchase History {visibleOrders ? `(${visibleOrders.length})` : ''}


### PR DESCRIPTION
This pull request introduces support for classroom-scoped admins and TAs to view student purchase history in the bazaar, both in the backend API and the frontend UI. It ensures that classroom-scoped admins/TAs can only access order data relevant to their classroom, improving permissions granularity and security.

**Backend: Classroom-scoped admin/TA permissions**
- Added `isClassroomAdmin` utility to check if a user is a classroom-scoped admin or TA, and updated the `/orders/user/:userId` endpoint to allow these users to view student orders, but only for orders within their classroom. Orders are filtered to include only those relevant to the classroom when accessed by a classroom admin/TA. [[1]](diffhunk://#diff-082a3049defe229c9ea54248c130484a584d374348175f23c4f6611a3396ea9cL12-R12) [[2]](diffhunk://#diff-082a3049defe229c9ea54248c130484a584d374348175f23c4f6611a3396ea9cR976-R982) [[3]](diffhunk://#diff-082a3049defe229c9ea54248c130484a584d374348175f23c4f6611a3396ea9cR1051-R1076)

**Frontend: UI updates for classroom-scoped admin/TA**
- Added state and logic in `Profile.jsx` to detect if the current viewer is a classroom-scoped admin/TA, and to conditionally fetch and display student purchase history accordingly. The frontend now passes the `classroomId` to the backend when a classroom-scoped admin/TA requests order history, and updates the UI to show the purchase history section for these users. [[1]](diffhunk://#diff-a4d7b8105f9172e600d0ac60255c6fc592aba0d03fc66bba6ede94512e203ba2R67-R68) [[2]](diffhunk://#diff-a4d7b8105f9172e600d0ac60255c6fc592aba0d03fc66bba6ede94512e203ba2R185-R224) [[3]](diffhunk://#diff-a4d7b8105f9172e600d0ac60255c6fc592aba0d03fc66bba6ede94512e203ba2L212-R237) [[4]](diffhunk://#diff-a4d7b8105f9172e600d0ac60255c6fc592aba0d03fc66bba6ede94512e203ba2L796-R821)