### PR TITLE
fix: assign fetch/axios response in Challenge 5 verify flow

### DIFF
--- a/backend/routes/challengeVerify.js
+++ b/backend/routes/challengeVerify.js
@@ -19,7 +19,7 @@ router.post('/verify', async (req, res) => {
     const WAYNEAWS_API_URL = process.env.WAYNEAWS_API_URL 
       || 'https://bx7226tmz2.execute-api.us-east-1.amazonaws.com/prod';
 
-    await axios.post(`${WAYNEAWS_API_URL}/verify`, {
+    const response = await axios.post(`${WAYNEAWS_API_URL}/verify`, {
       username: username.trim(),
       secret: secret.trim()
     }, {

--- a/frontend/src/pages/Challenge5Site.jsx
+++ b/frontend/src/pages/Challenge5Site.jsx
@@ -49,9 +49,8 @@ const Challenge5Site = () => {
       const apiUrl = import.meta.env.VITE_WAYNEAWS_API_URL 
         || 'https://bx7226tmz2.execute-api.us-east-1.amazonaws.com/prod';
 
-      await fetch(`${apiUrl}/verify`, {
+      const response = await fetch(`${apiUrl}/verify`, {
         method: 'POST',
-        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },


### PR DESCRIPTION
## Summary
Fixes Challenge 5 WayneAWS verification failing with `response is not defined` after the API URL env var refactor.

## Changes
- Assign `fetch` response in `Challenge5Site.jsx` before reading JSON
- Assign `axios` response in `challengeVerify.js` proxy route
- Remove unnecessary `credentials: 'include'` from the verify request